### PR TITLE
WebSocket keepalive, duplicate-session handling, and dispatcher deadlock fixes

### DIFF
--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -509,8 +509,13 @@ func (d *DefaultServerDispatcher) SendRequest(clientID string, req RequestBundle
 	log.Infof("[DefaultServerDispatcher] ESP SendRequest: About to acquire lock for %s (client: %s)", req.Call.UniqueId, clientID)
 	d.mutex.RLock()
 	log.Infof("[DefaultServerDispatcher] ESP SendRequest: Acquired lock, about to write to channel for %s (client: %s)", req.Call.UniqueId, clientID)
-	d.requestChannel <- clientID
-	log.Infof("[DefaultServerDispatcher] ESP SendRequest: Wrote to channel, about to release lock for %s (client: %s)", req.Call.UniqueId, clientID)
+	select {
+	case d.requestChannel <- clientID:
+		log.Infof("[DefaultServerDispatcher] ESP SendRequest: Wrote to channel for %s (client: %s)", req.Call.UniqueId, clientID)
+	default:
+		log.Infof("[DefaultServerDispatcher] ESP SendRequest: requestChannel full, skipping signal for %s (client: %s)", req.Call.UniqueId, clientID)
+	}
+	log.Infof("[DefaultServerDispatcher] ESP SendRequest: about to release lock for %s (client: %s)", req.Call.UniqueId, clientID)
 	d.mutex.RUnlock()
 	log.Infof("[DefaultServerDispatcher] ESP SendRequest: Released lock for %s (client: %s)", req.Call.UniqueId, clientID)
 	return nil
@@ -684,7 +689,11 @@ func (d *DefaultServerDispatcher) waitForTimeout(clientID string, clientCtx clie
 			d.mutex.RLock()
 			defer d.mutex.RUnlock()
 			if d.running {
-				d.timerC <- clientID
+				select {
+				case d.timerC <- clientID:
+				default:
+					log.Debugf("[DefaultServerDispatcher] waitForTimeout: timerC full, skipping signal for client %s", clientID)
+				}
 			}
 		} else {
 			log.Debugf("timeout canceled for %s", clientID)
@@ -716,8 +725,12 @@ func (d *DefaultServerDispatcher) CompleteRequest(clientID string, requestID str
 	log.Debugf("completed request %s for %s", callID, clientID)
 	// Signal that next message in queue may be sent
 	log.Debugf("[DefaultServerDispatcher] CompleteRequest: about to write to readyForDispatch for client %s", clientID)
-	d.readyForDispatch <- clientID
-	log.Debugf("[DefaultServerDispatcher] CompleteRequest: wrote to readyForDispatch for client %s", clientID)
+	select {
+	case d.readyForDispatch <- clientID:
+		log.Debugf("[DefaultServerDispatcher] CompleteRequest: wrote to readyForDispatch for client %s", clientID)
+	default:
+		log.Debugf("[DefaultServerDispatcher] CompleteRequest: readyForDispatch full, skipping signal for client %s", clientID)
+	}
 }
 
 // CheckHealth returns diagnostic information about the dispatcher's current state

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -315,12 +315,12 @@ type Server struct {
 func NewServer() *Server {
 	router := mux.NewRouter()
 	return &Server{
-		httpServer:   &http.Server{
-            ReadHeaderTimeout: 10 * time.Second,
-            ReadTimeout:       30 * time.Second,
-            WriteTimeout:      60 * time.Second,
-            IdleTimeout:       120 * time. Second,
-        },
+		httpServer: &http.Server{
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      60 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		},
 		timeoutConfig: NewServerTimeoutConfig(),
 		upgrader:      websocket.Upgrader{Subprotocols: []string{}},
 		httpHandler:   router,
@@ -610,15 +610,17 @@ out:
 		_ = conn.Close()
 		return
 	}
-	// Check whether client exists
+	// Check whether client exists — close the old connection, keep the new one
 	if existingWsInterface, exists := server.connections.Load(id); exists {
 		existingWs := existingWsInterface.(*WebSocket)
-		log.Debugf("[ESP-WS] Client %s already exists, replacing with new connection", id)
+		log.Debugf("[ESP-WS] Client %s already exists, closing old connection", id)
+
 		_ = existingWs.connection.WriteControl(websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseGoingAway, "connection superseded by a new session"),
+			websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "a new connection with this ID was established"),
 			time.Now().Add(server.timeoutConfig.WriteWait))
-		log.Debugf("[ESP-WS] Cleaning up existing connection for %s", id)
+
 		server.cleanupConnection(existingWs)
+		log.Debugf("[ESP-WS] Old connection cleaned up for %s, accepting new connection", id)
 	}
 	// Add new client
 	log.Debugf("[ESP-WS] Storing new connection for %s in sync.Map", id)

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -32,6 +32,8 @@ const (
 	defaultPongWait = 60 * time.Second
 	// Time allowed to wait for a ping on the server, before closing a connection due to inactivity.
 	defaultPingWait = defaultPongWait
+	// Default time to wait for a pong response from the client on the server side.
+	defaultServerPongWait = 60 * time.Second
 	// Send pings to peer with this period. Must be less than pongWait.
 	defaultPingPeriod = (defaultPongWait * 9) / 10
 	// Time allowed for the initial handshake to complete.
@@ -71,15 +73,22 @@ func SetLogger(logger logging.Logger) {
 // To set a custom configuration, refer to the server's SetTimeoutConfig method.
 // If no configuration is passed, a default configuration is generated via the NewServerTimeoutConfig function.
 type ServerTimeoutConfig struct {
-	WriteWait time.Duration
-	PingWait  time.Duration
+	WriteWait  time.Duration
+	PingWait   time.Duration // Deprecated: read-inactivity timeout. Used only when PingPeriod == 0.
+	PingPeriod time.Duration // Server-initiated ping interval. 0 = disabled (backward compatible).
+	PongWait   time.Duration // Max time to wait for pong. Only used when PingPeriod > 0.
 }
 
 // NewServerTimeoutConfig creates a default timeout configuration for a websocket endpoint.
 //
 // You may change fields arbitrarily and pass the struct to a SetTimeoutConfig method.
 func NewServerTimeoutConfig() ServerTimeoutConfig {
-	return ServerTimeoutConfig{WriteWait: defaultWriteWait, PingWait: defaultPingWait}
+	return ServerTimeoutConfig{
+		WriteWait:  defaultWriteWait,
+		PingWait:   defaultPingWait,
+		PingPeriod: 0,
+		PongWait:   defaultServerPongWait,
+	}
 }
 
 // Config contains optional configuration parameters for a websocket client.
@@ -431,8 +440,9 @@ func (server *Server) CheckHealth() string {
 		addrInfo = server.addr.String()
 	}
 
-	return fmt.Sprintf(`{"component":"WsServer","connections":%d,"address":"%s","writeWait":"%v","pingWait":"%v","connectionDetails":%s}`,
+	return fmt.Sprintf(`{"component":"WsServer","connections":%d,"address":"%s","writeWait":"%v","pingWait":"%v","pingPeriod":"%v","pongWait":"%v","connectionDetails":%s}`,
 		connectionCount, addrInfo, server.timeoutConfig.WriteWait, server.timeoutConfig.PingWait,
+		server.timeoutConfig.PingPeriod, server.timeoutConfig.PongWait,
 		"["+strings.Join(connections, ",")+"]")
 }
 
@@ -625,6 +635,14 @@ out:
 }
 
 func (server *Server) getReadTimeout() time.Time {
+	if server.timeoutConfig.PingPeriod > 0 {
+		// Server-initiated ping mode: use PongWait as the read deadline
+		if server.timeoutConfig.PongWait == 0 {
+			return time.Time{}
+		}
+		return time.Now().Add(server.timeoutConfig.PongWait)
+	}
+	// Legacy mode: use PingWait (read inactivity timeout)
 	if server.timeoutConfig.PingWait == 0 {
 		return time.Time{}
 	}
@@ -636,15 +654,17 @@ func (server *Server) readPump(ws *WebSocket) {
 	log.Debugf("[ESP-WS] Starting readPump for %s", ws.ID())
 
 	conn.SetPingHandler(func(appData string) error {
-		log.Debugf("[ESP-WS] Ping received from %s", ws.ID())
+		log.Debugf("[ESP-WS] Ping received from %s (payload=%q, len=%d)", ws.ID(), appData, len(appData))
 		if !ws.isClosed.Load() {
 			select {
 			case ws.pingMessage <- []byte(appData):
-				// Successfully sent ping message
+				log.Debugf("[ESP-WS] Ping message queued for pong reply to %s", ws.ID())
 			default:
 				// Channel is closed or full, ignore silently
-				log.Debugf("[ESP-WS] Ping message channel unavailable for %s", ws.ID())
+				log.Debugf("[ESP-WS] Ping message channel unavailable for %s (full or closed)", ws.ID())
 			}
+		} else {
+			log.Debugf("[ESP-WS] Ping received but connection already closed for %s", ws.ID())
 		}
 		err := conn.SetReadDeadline(server.getReadTimeout())
 		if err != nil {
@@ -652,6 +672,14 @@ func (server *Server) readPump(ws *WebSocket) {
 		}
 		return err
 	})
+
+	// Handle pong responses (for server-initiated pings)
+	if server.timeoutConfig.PingPeriod > 0 {
+		conn.SetPongHandler(func(appData string) error {
+			log.Debugf("[ESP-WS] Pong received from %s", ws.ID())
+			return conn.SetReadDeadline(server.getReadTimeout())
+		})
+	}
 
 	_ = conn.SetReadDeadline(server.getReadTimeout())
 
@@ -706,6 +734,26 @@ func (server *Server) writePump(ws *WebSocket) {
 	log.Debugf("[ESP-WS] Starting writePump for %s", ws.ID())
 	conn := ws.connection
 
+	// Set up optional server-initiated ping ticker
+	var tickerC <-chan time.Time
+	var ticker *time.Ticker
+	if server.timeoutConfig.PingPeriod > 0 {
+		if server.timeoutConfig.PingPeriod >= server.timeoutConfig.PongWait {
+			log.Errorf("[ESP-WS] PingPeriod (%v) should be less than PongWait (%v) for %s",
+				server.timeoutConfig.PingPeriod, server.timeoutConfig.PongWait, ws.ID())
+		}
+		ticker = time.NewTicker(server.timeoutConfig.PingPeriod)
+		tickerC = ticker.C
+		log.Debugf("[ESP-WS] Ping ticker started for %s (period=%v)", ws.ID(), server.timeoutConfig.PingPeriod)
+	}
+
+	cleanup := func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+		server.cleanupConnection(ws)
+	}
+
 	for {
 		select {
 		case data, ok := <-ws.outQueue:
@@ -718,7 +766,28 @@ func (server *Server) writePump(ws *WebSocket) {
 			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
 				log.Debugf("[ESP-WS] Write error for %s: %v", ws.ID(), err)
 				server.error(fmt.Errorf("write failed for %s: %w", ws.ID(), err))
-				server.cleanupConnection(ws)
+				cleanup()
+				return
+			}
+		case pingData, ok := <-ws.pingMessage:
+			if !ok {
+				return
+			}
+			log.Debugf("[ESP-WS] Sending pong reply to %s", ws.ID())
+			_ = conn.SetWriteDeadline(time.Now().Add(server.timeoutConfig.WriteWait))
+			if err := conn.WriteMessage(websocket.PongMessage, pingData); err != nil {
+				log.Debugf("[ESP-WS] Pong send error for %s: %v", ws.ID(), err)
+				server.error(fmt.Errorf("pong failed for %s: %w", ws.ID(), err))
+				cleanup()
+				return
+			}
+		case <-tickerC:
+			log.Debugf("[ESP-WS] Sending periodic ping to %s", ws.ID())
+			_ = conn.SetWriteDeadline(time.Now().Add(server.timeoutConfig.WriteWait))
+			if err := conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
+				log.Debugf("[ESP-WS] Ping send error for %s: %v", ws.ID(), err)
+				server.error(fmt.Errorf("ping failed for %s: %w", ws.ID(), err))
+				cleanup()
 				return
 			}
 		case closeErr := <-ws.closeC:
@@ -731,7 +800,7 @@ func (server *Server) writePump(ws *WebSocket) {
 				log.Debugf("[ESP-WS] Error sending close message for %s: %v", ws.ID(), err)
 			}
 			log.Debugf("[ESP-WS] Invoking cleanup after close signal for %s", ws.ID())
-			server.cleanupConnection(ws)
+			cleanup()
 			return
 		case pingData, ok := <-ws.pingMessage:
 			if !ok {
@@ -750,7 +819,7 @@ func (server *Server) writePump(ws *WebSocket) {
 			log.Debugf("[ESP-WS] Force close signal received for %s (ok=%v, err=%v)", ws.ID(), ok, closed)
 			if !ok || closed != nil {
 				log.Debugf("[ESP-WS] Invoking cleanup after force close for %s", ws.ID())
-				server.cleanupConnection(ws)
+				cleanup()
 			}
 			return
 		}


### PR DESCRIPTION
## Proposed changes

This PR bundles three related hardening and behavior improvements for OCPP WebSocket and request dispatching.

### 1. Server-initiated WebSocket pings (`feat(ws): support server-initiated WebSocket pings`)

- Add `ServerTimeoutConfig.PingPeriod` (default `0`: **unchanged** legacy behavior using `PingWait` for read inactivity).
- When `PingPeriod > 0`: server sends periodic RFC 6455 **ping** control frames, uses **pong** handling and `PongWait` for read deadlines, and answers **inbound** client pings from the write pump (avoids concurrent writes on the same connection).
- Log misconfiguration when `PingPeriod >= PongWait`; extend server `CheckHealth` JSON with `pingPeriod`.

### 2. Dispatcher deadlock avoidance (`fix(ocppj): use non-blocking sends to avoid DefaultServerDispatcher deadlocks`)

- Replace blocking sends on internal coordination channels with **non-blocking** `select` / `default` for `requestChannel`, `timerC`, and `readyForDispatch`.
- Avoids scenarios where a goroutine holds `d.mutex.RLock()` and blocks on a full channel while the MessagePump needs the lock, which could **deadlock** the dispatcher.
- When a buffer is full, the signal is skipped and logged instead of blocking.

### 3. Duplicate charger ID on connect (`fix(ws): replace duplicate connection by closing old peer only`)

- When a new WebSocket upgrade uses an ID that is **already** connected: **close and clean up the old** connection, **accept the new** one (no longer rejecting the new session in the supersession path we align with here).
- Old peer receives `ClosePolicyViolation` with reason indicating a new connection for the same ID; logs clarify “closing old connection” / “accepting new connection”.

## Commits

| Commit     | Summary |
| ---------- | ------- |
| `778247a` | feat(ws): support server-initiated WebSocket pings |
| `1eae78e` | fix(ocppj): use non-blocking sends to avoid DefaultServerDispatcher deadlocks |
| `a346b6b` | fix(ws): replace duplicate connection by closing old peer only |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

- **Ping feature**: Opt-in via `PingPeriod`; default remains backward compatible for existing deployments.
- **Dispatcher**: Defensive non-blocking sends trade strict “every signal delivered” semantics for **liveness** under load; worth monitoring logs for “channel full, skipping signal” if tuning buffer sizes.
- **Duplicate ID**: Improves behavior when a station reconnects with the same identity while an old session is still present (e.g. flaky network); old session is explicitly torn down so the new upgrade can proceed.
