### PR TITLE
feat(logging): add runtime filter logger and debug HTTP controls

### DIFF
--- a/logging/events.go
+++ b/logging/events.go
@@ -1,0 +1,15 @@
+package logging
+
+// Event represents a category of log events that can be selectively enabled or disabled.
+type Event string
+
+const (
+	EventConnect     Event = "connect"      // client connect
+	EventDisconnect  Event = "disconnect"   // client disconnect
+	EventMessageIn   Event = "message_in"   // incoming CALL / CALLRESULT / CALLERROR
+	EventMessageOut  Event = "message_out"  // enqueued / sent CALL / CALLRESULT / CALLERROR
+	EventDispatch    Event = "dispatch"     // OCPP handler invocation
+	EventWS          Event = "ws"           // ws read / write / ping
+	EventServerState Event = "server_state" // Start / Stop
+	EventServerHealth Event = "server_health" // capacity, backpressure, stalls
+)

--- a/logging/filter.go
+++ b/logging/filter.go
@@ -1,0 +1,209 @@
+package logging
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// FilterState is a snapshot of the current filter configuration.
+type FilterState struct {
+	DebugEnabled  bool            `json:"debug_enabled"`
+	EnabledEvents map[Event]bool  `json:"enabled_events"`
+	TracedClients map[string]bool `json:"traced_clients"`
+}
+
+// FilteringLogger wraps an underlying Logger and holds runtime-controllable
+// filter state. It implements the Logger interface as a pure passthrough —
+// all log calls are forwarded unconditionally to the underlying logger so
+// that logrus hooks (e.g. SQS pipeline) always fire.
+//
+// The ShouldEmit method is used by application-level hooks (e.g. ConsoleHook)
+// to decide whether a log entry should be printed to console/CloudWatch.
+//
+// Filtering is based on three mechanisms:
+//   - Global debug toggle: when enabled, everything prints
+//   - Per-client tracing: logs containing a traced client ID print
+//   - Event categories: logs matching a registered event pattern print when that event is enabled
+type FilteringLogger struct {
+	underlying    Logger
+	mu            sync.RWMutex
+	debugEnabled  bool
+	tracedClients map[string]bool
+	enabledEvents map[Event]bool
+	eventPatterns map[Event][]string // event -> list of message substrings
+}
+
+// NewFilteringLogger creates a FilteringLogger wrapping the given Logger.
+func NewFilteringLogger(underlying Logger) *FilteringLogger {
+	return &FilteringLogger{
+		underlying:    underlying,
+		tracedClients: make(map[string]bool),
+		enabledEvents: make(map[Event]bool),
+		eventPatterns: make(map[Event][]string),
+	}
+}
+
+// Logger interface — pure passthrough so all logrus hooks fire.
+
+func (fl *FilteringLogger) Debug(args ...interface{})                 { fl.underlying.Debug(args...) }
+func (fl *FilteringLogger) Debugf(format string, args ...interface{}) { fl.underlying.Debugf(format, args...) }
+func (fl *FilteringLogger) Info(args ...interface{})                  { fl.underlying.Info(args...) }
+func (fl *FilteringLogger) Infof(format string, args ...interface{})  { fl.underlying.Infof(format, args...) }
+func (fl *FilteringLogger) Error(args ...interface{})                 { fl.underlying.Error(args...) }
+func (fl *FilteringLogger) Errorf(format string, args ...interface{}) { fl.underlying.Errorf(format, args...) }
+
+// RegisterEventPattern associates a message substring with an event category.
+// When the event is enabled, any log message containing the pattern will print.
+// Call this at application init time to map library log messages to events.
+func (fl *FilteringLogger) RegisterEventPattern(e Event, pattern string) {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	fl.eventPatterns[e] = append(fl.eventPatterns[e], pattern)
+}
+
+// EnableEvent toggles an event category on or off.
+func (fl *FilteringLogger) EnableEvent(e Event, on bool) {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	if on {
+		fl.enabledEvents[e] = true
+	} else {
+		delete(fl.enabledEvents, e)
+	}
+}
+
+// EnableDebug toggles global debug logging on or off.
+func (fl *FilteringLogger) EnableDebug(on bool) {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	fl.debugEnabled = on
+}
+
+// TraceClient toggles per-chargepoint tracing on or off.
+func (fl *FilteringLogger) TraceClient(id string, on bool) {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	if on {
+		fl.tracedClients[id] = true
+	} else {
+		delete(fl.tracedClients, id)
+	}
+}
+
+// ShouldEmit checks whether a log entry should be printed to console output.
+// Returns true if:
+//   - debugEnabled (global toggle), OR
+//   - any traced client ID is found in the message, OR
+//   - the message matches a pattern of an enabled event
+//
+// Error-level entries should bypass this check (always print).
+func (fl *FilteringLogger) ShouldEmit(message string) bool {
+	fl.mu.RLock()
+	defer fl.mu.RUnlock()
+	if fl.debugEnabled {
+		return true
+	}
+	// Check traced clients
+	for id := range fl.tracedClients {
+		if strings.Contains(message, id) {
+			return true
+		}
+	}
+	// Check enabled events
+	for event := range fl.enabledEvents {
+		for _, pattern := range fl.eventPatterns[event] {
+			if strings.Contains(message, pattern) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Snapshot returns a copy of the current filter state.
+func (fl *FilteringLogger) Snapshot() FilterState {
+	fl.mu.RLock()
+	defer fl.mu.RUnlock()
+	events := make(map[Event]bool, len(fl.enabledEvents))
+	for k, v := range fl.enabledEvents {
+		events[k] = v
+	}
+	clients := make(map[string]bool, len(fl.tracedClients))
+	for k, v := range fl.tracedClients {
+		clients[k] = v
+	}
+	return FilterState{
+		DebugEnabled:  fl.debugEnabled,
+		EnabledEvents: events,
+		TracedClients: clients,
+	}
+}
+
+// DebugHTTPHandler returns an http.Handler for the /debug/loglevel endpoint.
+//
+// GET returns the current filter state as JSON.
+// POST accepts a JSON body:
+//
+//	{"debug":true}                          — toggle global debug
+//	{"event":"connect","enabled":true}      — toggle an event category
+//	{"client":"ENQ88N7PP","enabled":true}   — toggle per-chargepoint trace
+func (fl *FilteringLogger) DebugHTTPHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			fl.handleGet(w)
+		case http.MethodPost:
+			fl.handlePost(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func (fl *FilteringLogger) handleGet(w http.ResponseWriter) {
+	snap := fl.Snapshot()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(snap)
+}
+
+type toggleRequest struct {
+	Debug   *bool  `json:"debug,omitempty"`
+	Event   Event  `json:"event,omitempty"`
+	Client  string `json:"client,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+func (fl *FilteringLogger) handlePost(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var req toggleRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Debug == nil && req.Event == "" && req.Client == "" {
+		http.Error(w, "must specify \"debug\", \"event\", or \"client\"", http.StatusBadRequest)
+		return
+	}
+
+	if req.Debug != nil {
+		fl.EnableDebug(*req.Debug)
+	}
+	if req.Event != "" {
+		fl.EnableEvent(req.Event, req.Enabled)
+	}
+	if req.Client != "" {
+		fl.TraceClient(req.Client, req.Enabled)
+	}
+
+	fl.handleGet(w)
+}

--- a/logging/filter_test.go
+++ b/logging/filter_test.go
@@ -1,0 +1,261 @@
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type testLogger struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (l *testLogger) Debug(args ...interface{})                 { l.record("DEBUG", fmt.Sprint(args...)) }
+func (l *testLogger) Debugf(format string, args ...interface{}) { l.record("DEBUG", fmt.Sprintf(format, args...)) }
+func (l *testLogger) Info(args ...interface{})                  { l.record("INFO", fmt.Sprint(args...)) }
+func (l *testLogger) Infof(format string, args ...interface{})  { l.record("INFO", fmt.Sprintf(format, args...)) }
+func (l *testLogger) Error(args ...interface{})                 { l.record("ERROR", fmt.Sprint(args...)) }
+func (l *testLogger) Errorf(format string, args ...interface{}) { l.record("ERROR", fmt.Sprintf(format, args...)) }
+
+func (l *testLogger) record(level, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, level+": "+msg)
+}
+
+func (l *testLogger) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.messages)
+}
+
+func TestPassthrough(t *testing.T) {
+	tl := &testLogger{}
+	fl := NewFilteringLogger(tl)
+
+	fl.Debug("d")
+	fl.Debugf("df %d", 1)
+	fl.Info("i")
+	fl.Infof("if %d", 2)
+	fl.Error("e")
+	fl.Errorf("ef %d", 3)
+	if tl.count() != 6 {
+		t.Errorf("expected 6 passthrough logs, got %d", tl.count())
+	}
+}
+
+func TestShouldEmit_DefaultFalse(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	if fl.ShouldEmit("some message") {
+		t.Error("expected false by default")
+	}
+}
+
+func TestShouldEmit_DebugEnabled(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.EnableDebug(true)
+	if !fl.ShouldEmit("any message") {
+		t.Error("expected true when debug enabled")
+	}
+}
+
+func TestShouldEmit_TracedClient(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.TraceClient("CP001", true)
+
+	if !fl.ShouldEmit("received JSON message from CP001: [2,...]") {
+		t.Error("expected true for traced client")
+	}
+	if fl.ShouldEmit("received JSON message from CP002: [2,...]") {
+		t.Error("expected false for untraced client")
+	}
+}
+
+func TestShouldEmit_TracedClientDisabled(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.TraceClient("CP001", true)
+	fl.TraceClient("CP001", false)
+	if fl.ShouldEmit("msg from CP001") {
+		t.Error("expected false after untrace")
+	}
+}
+
+func TestShouldEmit_EventEnabled(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.RegisterEventPattern(EventConnect, "Client connected")
+	fl.RegisterEventPattern(EventDisconnect, "Client disconnected")
+
+	// Events not enabled yet
+	if fl.ShouldEmit("[Server] Client connected: CP001") {
+		t.Error("expected false when event not enabled")
+	}
+
+	fl.EnableEvent(EventConnect, true)
+	if !fl.ShouldEmit("[Server] Client connected: CP001") {
+		t.Error("expected true when connect event enabled")
+	}
+	if fl.ShouldEmit("[Server] Client disconnected: CP001") {
+		t.Error("expected false for disconnect (not enabled)")
+	}
+
+	fl.EnableEvent(EventConnect, false)
+	if fl.ShouldEmit("[Server] Client connected: CP001") {
+		t.Error("expected false after disabling connect event")
+	}
+}
+
+func TestShouldEmit_MultiplePatterns(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.RegisterEventPattern(EventConnect, "Client connected")
+	fl.RegisterEventPattern(EventConnect, "Client connection setup completed")
+	fl.EnableEvent(EventConnect, true)
+
+	if !fl.ShouldEmit("[Server] Client connected: CP001") {
+		t.Error("expected true for first pattern")
+	}
+	if !fl.ShouldEmit("[Server] Client connection setup completed: CP001") {
+		t.Error("expected true for second pattern")
+	}
+}
+
+func TestShouldEmit_HealthEvent(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.RegisterEventPattern(EventServerHealth, "[health]")
+	fl.EnableEvent(EventServerHealth, true)
+
+	if !fl.ShouldEmit("[health] OCPP gateway alive") {
+		t.Error("expected true for health message")
+	}
+}
+
+func TestSnapshot(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.EnableDebug(true)
+	fl.EnableEvent(EventConnect, true)
+	fl.TraceClient("CP001", true)
+
+	snap := fl.Snapshot()
+	if !snap.DebugEnabled {
+		t.Error("expected debug enabled")
+	}
+	if !snap.EnabledEvents[EventConnect] {
+		t.Error("expected connect event enabled")
+	}
+	if !snap.TracedClients["CP001"] {
+		t.Error("expected CP001 traced")
+	}
+
+	// Snapshot is a copy
+	fl.EnableDebug(false)
+	if !snap.DebugEnabled {
+		t.Error("snapshot should be a copy")
+	}
+}
+
+func TestHTTPHandler_Get(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.EnableEvent(EventConnect, true)
+	fl.TraceClient("CP001", true)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/loglevel", nil)
+	fl.DebugHTTPHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var state FilterState
+	json.Unmarshal(w.Body.Bytes(), &state)
+	if !state.EnabledEvents[EventConnect] {
+		t.Error("expected connect event in response")
+	}
+	if !state.TracedClients["CP001"] {
+		t.Error("expected CP001 in response")
+	}
+}
+
+func TestHTTPHandler_PostEvent(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.RegisterEventPattern(EventConnect, "Client connected")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/debug/loglevel", strings.NewReader(`{"event":"connect","enabled":true}`))
+	fl.DebugHTTPHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !fl.Snapshot().EnabledEvents[EventConnect] {
+		t.Error("expected connect enabled after POST")
+	}
+}
+
+func TestHTTPHandler_PostDebug(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/debug/loglevel", strings.NewReader(`{"debug":true}`))
+	fl.DebugHTTPHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !fl.Snapshot().DebugEnabled {
+		t.Error("expected debug enabled after POST")
+	}
+}
+
+func TestHTTPHandler_PostClient(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/debug/loglevel", strings.NewReader(`{"client":"ENQ88N7PP","enabled":true}`))
+	fl.DebugHTTPHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !fl.Snapshot().TracedClients["ENQ88N7PP"] {
+		t.Error("expected client traced after POST")
+	}
+}
+
+func TestHTTPHandler_PostInvalid(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/debug/loglevel", strings.NewReader(`{"enabled":true}`))
+	fl.DebugHTTPHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	fl := NewFilteringLogger(&VoidLogger{})
+	fl.RegisterEventPattern(EventConnect, "Client connected")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			fl.ShouldEmit("[Server] Client connected: CP001")
+		}()
+		go func() {
+			defer wg.Done()
+			fl.EnableEvent(EventConnect, true)
+		}()
+		go func() {
+			defer wg.Done()
+			fl.TraceClient("CP001", true)
+		}()
+	}
+	wg.Wait()
+}

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -22,11 +22,18 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/lorenzodonini/ocpp-go/ocppj"
 	"github.com/lorenzodonini/ocpp-go/ws"
-	"github.com/sirupsen/logrus"
 )
 
 // The internal verbose logger
-var log logger.Logger = &logrus.Logger{}
+var log logger.Logger = &logger.VoidLogger{}
+
+// SetLogger sets a custom Logger implementation for the ocpp1.6 package.
+func SetLogger(l logger.Logger) {
+	if l == nil {
+		panic("cannot set a nil logger")
+	}
+	log = l
+}
 
 type centralSystem struct {
 	server                *ocppj.Server

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -98,11 +98,15 @@ type DefaultClientDispatcher struct {
 	timer               *time.Timer
 	paused              bool
 	timeout             time.Duration
+	channelBufferSize   int
 }
 
 const (
 	defaultTimeoutTick    = 24 * time.Hour
 	defaultMessageTimeout = 30 * time.Second
+
+	defaultClientChannelBufferSize = 1
+	defaultServerChannelBufferSize = 1500
 )
 
 // NewDefaultClientDispatcher creates a new DefaultClientDispatcher struct.
@@ -110,9 +114,10 @@ func NewDefaultClientDispatcher(queue RequestQueue) *DefaultClientDispatcher {
 	return &DefaultClientDispatcher{
 		requestQueue:        queue,
 		requestChannel:      nil,
-		readyForDispatch:    make(chan bool, 1),
+		readyForDispatch:    make(chan bool, defaultClientChannelBufferSize),
 		pendingRequestState: NewClientState(),
 		timeout:             defaultMessageTimeout,
+		channelBufferSize:   defaultClientChannelBufferSize,
 	}
 }
 
@@ -124,11 +129,19 @@ func (d *DefaultClientDispatcher) SetTimeout(timeout time.Duration) {
 	d.timeout = timeout
 }
 
+// SetChannelBufferSize sets the buffer size for internal dispatcher channels
+// (requestChannel and readyForDispatch). Must be called before Start().
+func (d *DefaultClientDispatcher) SetChannelBufferSize(size int) {
+	d.channelBufferSize = size
+	// Recreate readyForDispatch with new size (it's created in the constructor)
+	d.readyForDispatch = make(chan bool, size)
+}
+
 func (d *DefaultClientDispatcher) Start() {
 	log.Info("[DefaultClientDispatcher] Starting dispatcher")
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.requestChannel = make(chan bool, 1)
+	d.requestChannel = make(chan bool, d.channelBufferSize)
 	d.timer = time.NewTimer(defaultTimeoutTick) // Default to 24 hours tick
 	go d.messagePump()
 	log.Info("[DefaultClientDispatcher] Started dispatcher")
@@ -407,6 +420,7 @@ type DefaultServerDispatcher struct {
 	onRequestCancel     CanceledRequestHandler
 	network             ws.WsServer
 	mutex               sync.RWMutex
+	channelBufferSize   int
 }
 
 // Handler function to be invoked when a request gets canceled (either due to timeout or to other external factors).
@@ -425,10 +439,11 @@ func (c clientTimeoutContext) isActive() bool {
 // NewDefaultServerDispatcher creates a new DefaultServerDispatcher struct.
 func NewDefaultServerDispatcher(queueMap ServerQueueMap) *DefaultServerDispatcher {
 	d := &DefaultServerDispatcher{
-		queueMap:         queueMap,
-		requestChannel:   nil,
-		readyForDispatch: make(chan string, 1500),
-		timeout:          defaultMessageTimeout,
+		queueMap:          queueMap,
+		requestChannel:    nil,
+		readyForDispatch:  make(chan string, defaultServerChannelBufferSize),
+		timeout:           defaultMessageTimeout,
+		channelBufferSize: defaultServerChannelBufferSize,
 	}
 	d.pendingRequestState = NewServerState(&d.mutex)
 	return d
@@ -438,8 +453,8 @@ func (d *DefaultServerDispatcher) Start() {
 	log.Info("[DefaultServerDispatcher] Starting dispatcher")
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.requestChannel = make(chan string, 1500)
-	d.timerC = make(chan string, 1500)
+	d.requestChannel = make(chan string, d.channelBufferSize)
+	d.timerC = make(chan string, d.channelBufferSize)
 	d.stoppedC = make(chan struct{}, 1)
 	d.running = true
 	go d.messagePump()
@@ -463,6 +478,14 @@ func (d *DefaultServerDispatcher) Stop() {
 
 func (d *DefaultServerDispatcher) SetTimeout(timeout time.Duration) {
 	d.timeout = timeout
+}
+
+// SetChannelBufferSize sets the buffer size for internal dispatcher channels
+// (requestChannel, readyForDispatch, and timerC). Must be called before Start().
+func (d *DefaultServerDispatcher) SetChannelBufferSize(size int) {
+	d.channelBufferSize = size
+	// Recreate readyForDispatch with new size (it's created in the constructor)
+	d.readyForDispatch = make(chan string, size)
 }
 
 func (d *DefaultServerDispatcher) CreateClient(clientID string) {


### PR DESCRIPTION
## Proposed changes

This PR introduces a runtime-controllable logging filter in the logging package so operators can reduce noisy console output without losing full-fidelity logs in downstream pipelines (for example, logrus hooks that should still receive every line).

It also adds configurability for internal dispatcher channel buffer sizes in `ocppj`, allowing deployments to tune queueing behavior based on traffic profile and avoid hard-coded buffer limits.

`FilteringLogger` wraps an existing `Logger` and implements the full logger interface as a passthrough: all `Debug` / `Info` / `Error` calls are always forwarded to the underlying logger. `ShouldEmit(message string)` is used as a gate for console-style sinks and decides whether a line should be displayed based on configurable rules.

### Key changes

- **Global debug toggle**  
  When enabled, `ShouldEmit` allows all messages.
- **Per-client tracing**  
  Enable tracing for a charge point ID; any log line containing that substring is allowed through `ShouldEmit`.
- **Event categories**  
  `RegisterEventPattern` maps `Event` values to message substrings; `EnableEvent` toggles categories.  
  Errors are documented to always print at the application layer (callers should not filter `Error` via `ShouldEmit`).
- **HTTP control plane**  
  `DebugHTTPHandler()` exposes:
  - `GET`: JSON snapshot of current filter state
  - `POST`: JSON body to toggle debug, event, or client trace settings at runtime
- **Event constants**  
  Named categories for consistency across the codebase:  
  `connect`, `disconnect`, `message_in`, `message_out`, `dispatch`, `ws`, `server_state`, `server_health`.
- **Dispatcher channel buffer configurability**  
  Added configurable channel buffer sizes for client and server dispatchers in `ocppj/dispatcher.go`, replacing hard-coded buffer values with defaults plus setters (to be configured before `Start()`).
- **Tests**  
  Coverage for passthrough behavior, `ShouldEmit` rules, HTTP handler `GET/POST`, validation, concurrency, and dispatcher buffer-size configuration behavior.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Further comments

This is additive and does not change existing `Logger` implementations until callers opt in by wrapping with `NewFilteringLogger` and wiring `ShouldEmit` into their console hook/formatter.

Integration pattern: keep the underlying logger connected to your full log pipeline; apply `ShouldEmit` only at selective-display sinks (terminal output, reduced CloudWatch verbosity, etc.).

For the dispatcher change, defaults preserve existing behavior, while giving operators a tuning knob for high/low throughput environments.