### PR TITLE
feat(ws): add capacity-check handler returning HTTP 503

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -52,6 +53,10 @@ const (
 	// time, the first time it tries to reconnect.
 	defaultRetryBackOffWaitMinimum = 10 * time.Second
 )
+
+// DefaultCapacityRetryAfterSeconds is the value sent in the Retry-After header
+// when the capacity-check handler rejects an upgrade with 503.
+const DefaultCapacityRetryAfterSeconds = 30
 
 // The internal verbose logger
 var log logging.Logger
@@ -280,6 +285,12 @@ type WsServer interface {
 	// SetCheckClientHandler sets a handler for validate incoming websocket connections, allowing to perform
 	// custom client connection checks.
 	SetCheckClientHandler(handler func(id string, r *http.Request) bool)
+	// SetCapacityCheckHandler sets a handler called before basic-auth and the
+	// validation hook. Returning false causes the server to respond with
+	// HTTP 503 Service Unavailable and a Retry-After header, signalling that
+	// the server is at capacity and the client should retry later. This is
+	// distinct from the 401 emitted by SetCheckClientHandler / SetBasicAuthHandler.
+	SetCapacityCheckHandler(handler func(id string, r *http.Request) bool)
 	// Addr gives the address on which the server is listening, useful if, for
 	// example, the port is system-defined (set to 0).
 	Addr() *net.TCPAddr
@@ -295,20 +306,21 @@ type WsServer interface {
 //
 // Use the NewServer or NewTLSServer functions to create a new server.
 type Server struct {
-	connections         sync.Map
-	httpServer          *http.Server
-	messageHandler      func(ws Channel, data []byte) error
-	checkClientHandler  func(id string, r *http.Request) bool
-	newClientHandler    func(ws Channel)
-	disconnectedHandler func(ws Channel)
-	basicAuthHandler    func(username string, password string) bool
-	tlsCertificatePath  string
-	tlsCertificateKey   string
-	timeoutConfig       ServerTimeoutConfig
-	upgrader            websocket.Upgrader
-	errC                chan error
-	addr                *net.TCPAddr
-	httpHandler         *mux.Router
+	connections          sync.Map
+	httpServer           *http.Server
+	messageHandler       func(ws Channel, data []byte) error
+	checkClientHandler   func(id string, r *http.Request) bool
+	capacityCheckHandler func(id string, r *http.Request) bool
+	newClientHandler     func(ws Channel)
+	disconnectedHandler  func(ws Channel)
+	basicAuthHandler     func(username string, password string) bool
+	tlsCertificatePath   string
+	tlsCertificateKey    string
+	timeoutConfig        ServerTimeoutConfig
+	upgrader             websocket.Upgrader
+	errC                 chan error
+	addr                 *net.TCPAddr
+	httpHandler          *mux.Router
 }
 
 // Creates a new simple websocket server (the websockets are not secured).
@@ -361,6 +373,10 @@ func (server *Server) SetMessageHandler(handler func(ws Channel, data []byte) er
 
 func (server *Server) SetCheckClientHandler(handler func(id string, r *http.Request) bool) {
 	server.checkClientHandler = handler
+}
+
+func (server *Server) SetCapacityCheckHandler(handler func(id string, r *http.Request) bool) {
+	server.capacityCheckHandler = handler
 }
 
 func (server *Server) SetNewClientHandler(handler func(ws Channel)) {
@@ -558,6 +574,17 @@ out:
 	}
 	if negotiatedSuprotocol != "" {
 		responseHeader.Add("Sec-WebSocket-Protocol", negotiatedSuprotocol)
+	}
+	// Capacity check runs before auth + validation. Reject with 503 +
+	// Retry-After when the server is at capacity, distinct from the 401
+	// emitted by auth/validation failures.
+	if server.capacityCheckHandler != nil {
+		if ok := server.capacityCheckHandler(id, r); !ok {
+			server.error(fmt.Errorf("capacity check: rejecting %s, server at capacity", id))
+			w.Header().Set("Retry-After", strconv.Itoa(DefaultCapacityRetryAfterSeconds))
+			http.Error(w, "Service Unavailable: at capacity", http.StatusServiceUnavailable)
+			return
+		}
 	}
 	// Handle client authentication
 	if server.basicAuthHandler != nil {


### PR DESCRIPTION
## Proposed changes

Adds `SetCapacityCheckHandler` on the WebSocket server so operators can reject new connections when a task is at capacity **before** basic auth and the existing client-validation hook run.

When the handler returns `false`, the upgrade response is **HTTP 503 Service Unavailable** with a **Retry-After** header (default **30** seconds via `DefaultCapacityRetryAfterSeconds`). That keeps “full / back off” distinct from **401** used for auth failures.

**Why:** With an ALB using `least_outstanding_requests`, tasks that quickly **401** capacity-style checks can look “idle” to the load balancer and receive disproportionate new connection attempts compared to tasks already holding long-lived WebSockets. **503 + Retry-After** encourages clients to retry elsewhere or shortly after, and lets metrics/alerts separate capacity rejection from authentication failure.

**Scope:** `ws/websocket.go` only.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

- Handler order: capacity check → basic auth → client validation (unchanged relative ordering aside from the new first step).
- Default retry interval is a package constant; adjust if you want a different default or make it configurable in a follow-up.
- Co-authored commit attribution is already in the commit message; retain if your org cares about that line in squash merges.